### PR TITLE
Add links to slack and web in profile page

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -34,3 +34,11 @@ Follow us on
 <a style="padding-right:10px;" href="https://dev.to/one-beyond">
 <img alt="dev.to" src="https://img.shields.io/badge/dev.to-0A0A0A?style=for-the-badge&logo=devdotto&logoColor=white" />
 </a>
+
+<a style="padding-right:10px;" href="https://onebeyondopensource.slack.com">
+<img alt="slack" src="https://img.shields.io/badge/slack-36C5F0?style=for-the-badge&logo=slack&logoColor=white" />
+</a>
+
+<a style="padding-right:10px;" href="https://www.one-beyond.com">
+<img alt="One Beyond" src="https://img.shields.io/badge/onebeyond-0A0A0A?style=for-the-badge&logo=icloud&logoColor=white" />
+</a>


### PR DESCRIPTION
## Description

- Add links to slack and web in profile page

## Motivation and Context

Slack and Web reference were missing in the main GitHub profile of the OpenSource organization.

## Screenshots

<img width="207" alt="Captura de pantalla 2023-03-24 a las 9 52 15" src="https://user-images.githubusercontent.com/25435858/227471104-9e374362-9b1b-499b-b5c1-8f335b9dbd72.png">

